### PR TITLE
License Information Update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2010-2016, Frédéric Hardy.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Frédéric Hardy nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY FRÉDÉRIC HARDY AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL FRÉDÉRIC HARDY AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# atoum/visibility-extension [![Build Status](https://travis-ci.org/atoum/visibility-extension.svg?branch=master)](https://travis-ci.org/atoum/visibility-extension)
+# atoum/visibility-extension [![Build Status](https://travis-ci.org/atoum/visibility-extension.svg?branch=master)](https://travis-ci.org/atoum/visibility-extension) [![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 ![atoum](http://downloads.atoum.org/images/logo.png)
-![https://opensource.org/licenses/BSD-3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)
 
 ## Install it
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # atoum/visibility-extension [![Build Status](https://travis-ci.org/atoum/visibility-extension.svg?branch=master)](https://travis-ci.org/atoum/visibility-extension)
 
 ![atoum](http://downloads.atoum.org/images/logo.png)
-![https://opensource.org/licenses/BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)
+![https://opensource.org/licenses/BSD-3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)
 
 ## Install it
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # atoum/visibility-extension [![Build Status](https://travis-ci.org/atoum/visibility-extension.svg?branch=master)](https://travis-ci.org/atoum/visibility-extension)
 
 ![atoum](http://downloads.atoum.org/images/logo.png)
+![https://opensource.org/licenses/BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)
 
 ## Install it
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "atoum extension to loosen method visibility",
     "keywords": ["TDD","atoum","test","unit testing","visibility"],
     "homepage": "http://www.atoum.org",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "jubianchi",


### PR DESCRIPTION
This will resolve #13.

I updated the added the `LICENSE` file and updated `composer.json` as well as the `README.md`. The license is displayed in the README via a shields.io badge. Perhaps it would be better to replace the image URL with a self-hosted copy but for now this works.