### PR TITLE
Fix README wrong version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install extension using [composer](https://getcomposer.org):
 ```json
 {
     "require-dev": {
-        "atoum/visibility-extension": "~2.0"
+        "atoum/visibility-extension": "~1.1"
     },
 }
 


### PR DESCRIPTION
It seems that you already faced something similar here #10 ... but still, I find this really confusing. When I land to a GitHub repository, I just read the installation doc on the master branch and use it...
